### PR TITLE
査定回答ページの作成

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["next/core-web-vitals", "next/typescript"]
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "off"
+  }
 }

--- a/src/app/buyer/newPost/page.tsx
+++ b/src/app/buyer/newPost/page.tsx
@@ -1,24 +1,25 @@
 'use client'
 
-import { useForm } from 'react-hook-form'
+import { FormProvider, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import * as z from 'zod'
 import { Button } from "@/components/ui/button"
-import { Form } from "@/components/ui/form"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import Header from '@/features/components/Header'
-import Brand from '@/features/components/newPost/Brand'
+import Brand from '@/features/form/Brand'
 import { formSchema } from '@/lib/schemas/formSchema'
-import EstimatedPrice from '@/features/components/newPost/EstimatedPrice'
-import Condition from '@/features/components/newPost/Condition'
-import ConditionDetails from '@/features/components/newPost/ConditionDetails'
-import Notes from '@/features/components/newPost/Notes'
-import Images from '@/features/components/newPost/Images'
+import EstimatedPrice from '@/features/form/EstimatedPrice'
+import Condition from '@/features/form/Condition'
+import ConditionDetails from '@/features/form/ConditionDetails'
+import Notes from '@/features/form/Notes'
+import Images from '@/features/form/Images'
+import { Undo2 } from 'lucide-react'
+import Link from 'next/link'
 
 export default function AssessmentForm() {
 
-  const form = useForm<z.infer<typeof formSchema>>({
+  const { control, handleSubmit, setValue, formState: {errors} } = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
       brand: "",
@@ -29,6 +30,7 @@ export default function AssessmentForm() {
       images: []
     },
   })
+  const methods = useForm();
 
   function onSubmit(values: z.infer<typeof formSchema>) {
     console.log(values)
@@ -45,25 +47,31 @@ export default function AssessmentForm() {
           <CardDescription className="text-blue-100">商品の詳細情報を入力してください</CardDescription>
         </CardHeader>
         <CardContent className="p-6">
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+          <FormProvider {...methods}>
+            <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <Brand form={form} />
-                <EstimatedPrice form={form} />
+                <Brand control={control} errors={errors}/>
+                <EstimatedPrice control={control} errors={errors}/>
               </div>
               <Separator className="my-6" />
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <Condition form={form} />
-                <ConditionDetails form={form} />
+                <Condition control={control} errors={errors} />
+                <ConditionDetails control={control} />
               </div>
               <Separator className="my-6" />
-              <Notes form={form} />
-              <Images form={form} />
+              <Notes control={control} />
+              <Images control={control} setValue={setValue} errors={errors} />
               <Button type="submit" className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-bold py-3 px-6 rounded-lg shadow-lg transition duration-300 ease-in-out transform hover:-translate-y-1 hover:scale-105">
                 査定を依頼する
               </Button>
             </form>
-          </Form>
+          </FormProvider>
+          <Link href={'/buyer/Home'}>
+            <Button className='w-full bg-gray-600 hover:bg-gray-700 mt-3'>
+              <Undo2 className="w-4 h-4 mr-2" />
+              <span>依頼せずに戻る</span>
+            </Button>
+          </Link>
         </CardContent>
       </Card>
     </div>

--- a/src/app/post-response/[id]/page.tsx
+++ b/src/app/post-response/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import * as z from 'zod'
 import { useParams } from 'next/navigation'
 import Image from 'next/image'
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "@/components/ui/card"
@@ -13,6 +13,10 @@ import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
 import { FileText, Save, Undo2, Tag, FileDigit, Receipt } from 'lucide-react'
 import Link from 'next/link'
 import Header from '@/features/components/Header'
+import { useForm } from 'react-hook-form'
+import { responseSchema } from '@/lib/schemas/formSchema'
+import { zodResolver } from '@hookform/resolvers/zod'
+import Brand from '@/features/form/Brand'
 
 // Placeholder data
 const initialAssessmentData = {
@@ -34,26 +38,24 @@ const initialAssessmentData = {
 }
 
 export default function AssessmentResponse() {
-    const [assessmentData, setAssessmentData] = useState(initialAssessmentData)
+
+    const form = useForm<z.infer<typeof responseSchema>>({
+        resolver: zodResolver(responseSchema),
+        defaultValues: {
+            brand: initialAssessmentData.brandName,
+            responseMin: initialAssessmentData.responseRange.min,
+            responseMax: initialAssessmentData.responseRange.max,
+            modelName: initialAssessmentData.modelName,
+            serialNumber: initialAssessmentData.serialNumber,
+        },
+    })
 
     const params = useParams()
     const id = params.id
 
-    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const { name, value } = e.target
-        setAssessmentData(prev => ({ ...prev, [name]: value }))
-    }
-
-    const handleRangeChange = (type: 'min' | 'max', value: string) => {
-        setAssessmentData(prev => ({
-        ...prev,
-        responseRange: { ...prev.responseRange, [type]: parseInt(value) || 0 }
-        }))
-    }
-
     const handleSave = () => {
         // Here you would typically make an API call to save the data
-        console.log('Saving response data:', assessmentData)
+        console.log('Saving response data:')
         console.log("査定回答が正常に保存されました。")
         // Redirect to a confirmation page or back to the list (you'll need to implement this route)
     }
@@ -71,16 +73,7 @@ export default function AssessmentResponse() {
                 <CardContent className="grid gap-6">
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div className="space-y-2">
-                        <Label htmlFor="brandName" className="flex items-center text-lg font-semibold text-gray-700">
-                        <Tag className="w-5 h-5 mr-2 text-blue-500" />
-                        ブランド名
-                        </Label>
-                        <Input
-                        id="brandName"
-                        name="brandName"
-                        value={assessmentData.brandName}
-                        onChange={handleInputChange}
-                        />
+                        <Brand form={form} />
                     </div>
                     <div className="space-y-2">
                         <Label htmlFor="modelName" className="flex items-center text-lg font-semibold text-gray-700">

--- a/src/app/post-response/[id]/page.tsx
+++ b/src/app/post-response/[id]/page.tsx
@@ -4,19 +4,23 @@ import * as z from 'zod'
 import { useParams } from 'next/navigation'
 import Image from 'next/image'
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
 import { DialogTitle } from '@radix-ui/react-dialog'
+import { Separator } from '@/components/ui/separator'
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
-import { FileText, Save, Undo2, Tag, FileDigit, Receipt } from 'lucide-react'
+import { Save, Undo2 } from 'lucide-react'
 import Link from 'next/link'
 import Header from '@/features/components/Header'
-import { useForm } from 'react-hook-form'
+import { FormProvider, useForm } from 'react-hook-form'
 import { responseSchema } from '@/lib/schemas/formSchema'
 import { zodResolver } from '@hookform/resolvers/zod'
 import Brand from '@/features/form/Brand'
+import ModelName from '@/features/form/ModelName'
+import SerialNumber from '@/features/form/SerialNumber'
+import ResponseRangeMin from '@/features/form/ResponseRangeMin'
+import ResponseRangeMax from '@/features/form/ResponseRangeMax'
 
 // Placeholder data
 const initialAssessmentData = {
@@ -39,7 +43,7 @@ const initialAssessmentData = {
 
 export default function AssessmentResponse() {
 
-    const form = useForm<z.infer<typeof responseSchema>>({
+    const { control, handleSubmit, formState: {errors}} = useForm<z.infer<typeof responseSchema>>({
         resolver: zodResolver(responseSchema),
         defaultValues: {
             brand: initialAssessmentData.brandName,
@@ -49,13 +53,14 @@ export default function AssessmentResponse() {
             serialNumber: initialAssessmentData.serialNumber,
         },
     })
+    const methods = useForm();
 
     const params = useParams()
     const id = params.id
 
-    const handleSave = () => {
+    const onSubmit = (values: z.infer<typeof responseSchema>) => {
         // Here you would typically make an API call to save the data
-        console.log('Saving response data:')
+        console.log(values)
         console.log("査定回答が正常に保存されました。")
         // Redirect to a confirmation page or back to the list (you'll need to implement this route)
     }
@@ -71,91 +76,60 @@ export default function AssessmentResponse() {
                     <CardTitle className="text-2xl font-bold text-indigo-900">商品情報</CardTitle>
                 </CardHeader>
                 <CardContent className="grid gap-6">
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div className="space-y-2">
-                        <Brand form={form} />
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="modelName" className="flex items-center text-lg font-semibold text-gray-700">
-                        <FileText className="w-5 h-5 mr-2 text-purple-500" />
-                        モデル、ライン名
-                        </Label>
-                        <Input
-                        id="modelName"
-                        name="modelName"
-                        value={assessmentData.modelName}
-                        onChange={handleInputChange}
-                        />
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="serialNumber" className="flex items-center text-lg font-semibold text-gray-700">
-                        <FileDigit className="w-5 h-5 mr-2 text-indigo-500" />
-                        型番、シリアル
-                        </Label>
-                        <Input
-                        id="serialNumber"
-                        name="serialNumber"
-                        value={assessmentData.serialNumber}
-                        onChange={handleInputChange}
-                        />
-                    </div>
-                    <div className="space-y-2"></div>
-                    <div className="space-y-2">
-                        <Label htmlFor="responseRangeMin" className="flex items-center text-lg font-semibold text-gray-700">
-                        <Receipt className="w-5 h-5 mr-2 text-pink-500" />
-                        回答額（最小）
-                        </Label>
-                        <Input
-                        id="responseRangeMin"
-                        name="responseRangeMin"
-                        type="number"
-                        value={assessmentData.responseRange.min}
-                        onChange={(e) => handleRangeChange('min', e.target.value)}
-                        />
-                    </div>
-                    <div className="space-y-2">
-                        <Label htmlFor="responseRangeMax" className="flex items-center text-lg font-semibold text-gray-700">
-                        <Receipt className="w-5 h-5 mr-2 text-pink-500" />
-                        回答額（最大）
-                        </Label>
-                        <Input
-                        id="responseRangeMax"
-                        name="responseRangeMax"
-                        type="number"
-                        value={assessmentData.responseRange.max}
-                        onChange={(e) => handleRangeChange('max', e.target.value)}
-                        />
-                    </div>
-                    </div>
-                    
-                    {/* Display-only fields */}
+                    <FormProvider {...methods}>
+                        <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div className="space-y-2">
+                                <Brand control={control} errors={errors} />
+                            </div>
+                            <div className="space-y-2">
+                                <ModelName control={control} />
+                            </div>
+                            <div className="space-y-2">
+                                <SerialNumber control={control} />
+                            </div>
+                            <div className="space-y-2"></div>
+                            <div className="space-y-2">
+                                <ResponseRangeMin control={control} errors={errors} />
+                            </div>
+                            <div className="space-y-2">
+                                <ResponseRangeMax control={control} errors={errors} />
+                            </div>
+                            </div>
+                        <Button type="submit" className="w-full bg-blue-600 hover:bg-blue-700">
+                                <Save className="w-4 h-4 mr-2" />
+                                回答を保存
+                        </Button>
+                        </form>
+                    </FormProvider>
+                <Separator />
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
                     <div className="space-y-2">
                         <Label className="text-lg font-semibold text-gray-700">バイヤー予想額</Label>
-                        <p className="text-gray-600">¥{assessmentData.buyerEstimate.toLocaleString()}</p>
+                        <p className="text-gray-600">¥{initialAssessmentData.buyerEstimate.toLocaleString()}</p>
                     </div>
                     <div className="space-y-2">
                         <Label className="text-lg font-semibold text-gray-700">状態ランク</Label>
-                        <p className="text-gray-600">{assessmentData.conditionRank}</p>
+                        <p className="text-gray-600">{initialAssessmentData.conditionRank}</p>
                     </div>
                     <div className="space-y-2 md:col-span-2">
                         <Label className="text-lg font-semibold text-gray-700">状態補足</Label>
-                        <p className="text-gray-600">{assessmentData.conditionDetails}</p>
+                        <p className="text-gray-600">{initialAssessmentData.conditionDetails}</p>
                     </div>
                     <div className="space-y-2 md:col-span-2">
                         <Label className="text-lg font-semibold text-gray-700">備考</Label>
-                        <p className="text-gray-600">{assessmentData.notes}</p>
+                        <p className="text-gray-600">{initialAssessmentData.notes}</p>
                     </div>
                     <div className="space-y-2">
                         <Label className="text-lg font-semibold text-gray-700">投稿者</Label>
-                        <p className="text-gray-600">{assessmentData.poster}</p>
+                        <p className="text-gray-600">{initialAssessmentData.poster}</p>
                     </div>
                     </div>
 
                     <div className="space-y-2">
                     <Label className="text-lg font-semibold text-gray-700">投稿画像</Label>
                     <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                    {assessmentData.images.map((src, index) => (
+                    {initialAssessmentData.images.map((src, index) => (
                     <Dialog key={index}>
                         <DialogTrigger asChild>
                         <Image
@@ -183,11 +157,7 @@ export default function AssessmentResponse() {
                     </div>
                     </div>
                 </CardContent>
-                <CardFooter className='grid grid-rows-2 gap-4'>
-                    <Button onClick={handleSave} className="w-full bg-blue-600 hover:bg-blue-700">
-                        <Save className="w-4 h-4 mr-2" />
-                        回答を保存
-                    </Button>
+                <CardFooter className='grid grid-rows-1'>
                     <Link href={`/post-detail/${id}`}>
                         <Button className="w-full bg-gray-600 hover:bg-gray-700">
                             <Undo2 className="w-4 h-4 mr-2" />

--- a/src/app/post-response/[id]/page.tsx
+++ b/src/app/post-response/[id]/page.tsx
@@ -1,13 +1,18 @@
 'use client'
 
 import { useState } from 'react'
+import { useParams } from 'next/navigation'
 import Image from 'next/image'
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
+import { DialogTitle } from '@radix-ui/react-dialog'
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
-import { Camera, FileText, Hash, CreditCard, Save, ZoomIn, ZoomOut, Undo2 } from 'lucide-react'
+import { FileText, Save, Undo2, Tag, FileDigit, Receipt } from 'lucide-react'
+import Link from 'next/link'
+import Header from '@/features/components/Header'
 
 // Placeholder data
 const initialAssessmentData = {
@@ -30,7 +35,9 @@ const initialAssessmentData = {
 
 export default function AssessmentResponse() {
     const [assessmentData, setAssessmentData] = useState(initialAssessmentData)
-    const [zoomLevel, setZoomLevel] = useState(1)
+
+    const params = useParams()
+    const id = params.id
 
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const { name, value } = e.target
@@ -51,173 +58,153 @@ export default function AssessmentResponse() {
         // Redirect to a confirmation page or back to the list (you'll need to implement this route)
     }
 
-    const zoomIn = () => {
-        setZoomLevel(prevZoom => Math.min(prevZoom + 0.1, 3))
-    }
-
-    const zoomOut = () => {
-        setZoomLevel(prevZoom => Math.max(prevZoom - 0.1, 0.5))
-    }
-
-    const ImageDialog = ({ src, alt }: { src: string, alt: string }) => (
-        <Dialog>
-        <DialogTrigger asChild>
-            <Image
-            src={src}
-            alt={alt}
-            width={200}
-            height={200}
-            className="rounded-md object-cover w-full h-40 cursor-pointer"
-            />
-        </DialogTrigger>
-        <DialogContent className="max-w-3xl max-h-[90vh] flex flex-col">
-            <div className="relative flex-grow overflow-hidden">
-            <div className="absolute inset-0 flex items-center justify-center">
-                <Image
-                src={src}
-                alt={alt}
-                width={800}
-                height={800}
-                className="rounded-md object-contain"
-                style={{ transform: `scale(${zoomLevel})`, transition: 'transform 0.2s' }}
-                />
-            </div>
-            </div>
-            <div className="flex justify-center mt-4 space-x-2">
-            <Button onClick={zoomOut} variant="outline" size="icon">
-                <ZoomOut className="h-4 w-4" />
-                <span className="sr-only">縮小</span>
-            </Button>
-            <Button onClick={zoomIn} variant="outline" size="icon">
-                <ZoomIn className="h-4 w-4" />
-                <span className="sr-only">拡大</span>
-            </Button>
-            </div>
-        </DialogContent>
-        </Dialog>
-    )
-
     return (
-        <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 py-12 px-4 sm:px-6 lg:px-8">
-        <div className="max-w-3xl mx-auto">
-            <h1 className="text-3xl font-bold text-center text-indigo-900 mb-8">査定回答</h1>
-            <Card className="bg-white bg-opacity-90">
-            <CardHeader>
-                <CardTitle className="text-2xl font-bold text-indigo-900">商品情報</CardTitle>
-            </CardHeader>
-            <CardContent className="grid gap-6">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                    <Label htmlFor="brandName" className="flex items-center text-lg font-semibold text-gray-700">
-                    <Camera className="w-5 h-5 mr-2 text-blue-500" />
-                    ブランド名
-                    </Label>
-                    <Input
-                    id="brandName"
-                    name="brandName"
-                    value={assessmentData.brandName}
-                    onChange={handleInputChange}
-                    />
-                </div>
-                <div className="space-y-2">
-                    <Label htmlFor="modelName" className="flex items-center text-lg font-semibold text-gray-700">
-                    <FileText className="w-5 h-5 mr-2 text-purple-500" />
-                    モデル、ライン名
-                    </Label>
-                    <Input
-                    id="modelName"
-                    name="modelName"
-                    value={assessmentData.modelName}
-                    onChange={handleInputChange}
-                    />
-                </div>
-                <div className="space-y-2">
-                    <Label htmlFor="serialNumber" className="flex items-center text-lg font-semibold text-gray-700">
-                    <Hash className="w-5 h-5 mr-2 text-indigo-500" />
-                    型番、シリアル
-                    </Label>
-                    <Input
-                    id="serialNumber"
-                    name="serialNumber"
-                    value={assessmentData.serialNumber}
-                    onChange={handleInputChange}
-                    />
-                </div>
-                <div className="space-y-2"></div>
-                <div className="space-y-2">
-                    <Label htmlFor="responseRangeMin" className="flex items-center text-lg font-semibold text-gray-700">
-                    <CreditCard className="w-5 h-5 mr-2 text-pink-500" />
-                    回答額（最小）
-                    </Label>
-                    <Input
-                    id="responseRangeMin"
-                    name="responseRangeMin"
-                    type="number"
-                    value={assessmentData.responseRange.min}
-                    onChange={(e) => handleRangeChange('min', e.target.value)}
-                    />
-                </div>
-                <div className="space-y-2">
-                    <Label htmlFor="responseRangeMax" className="flex items-center text-lg font-semibold text-gray-700">
-                    <CreditCard className="w-5 h-5 mr-2 text-pink-500" />
-                    回答額（最大）
-                    </Label>
-                    <Input
-                    id="responseRangeMax"
-                    name="responseRangeMax"
-                    type="number"
-                    value={assessmentData.responseRange.max}
-                    onChange={(e) => handleRangeChange('max', e.target.value)}
-                    />
-                </div>
-                </div>
-                
-                {/* Display-only fields */}
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
-                <div className="space-y-2">
-                    <Label className="text-lg font-semibold text-gray-700">バイヤー予想額</Label>
-                    <p className="text-gray-600">¥{assessmentData.buyerEstimate.toLocaleString()}</p>
-                </div>
-                <div className="space-y-2">
-                    <Label className="text-lg font-semibold text-gray-700">状態ランク</Label>
-                    <p className="text-gray-600">{assessmentData.conditionRank}</p>
-                </div>
-                <div className="space-y-2 md:col-span-2">
-                    <Label className="text-lg font-semibold text-gray-700">状態補足</Label>
-                    <p className="text-gray-600">{assessmentData.conditionDetails}</p>
-                </div>
-                <div className="space-y-2 md:col-span-2">
-                    <Label className="text-lg font-semibold text-gray-700">備考</Label>
-                    <p className="text-gray-600">{assessmentData.notes}</p>
-                </div>
-                <div className="space-y-2">
-                    <Label className="text-lg font-semibold text-gray-700">投稿者</Label>
-                    <p className="text-gray-600">{assessmentData.poster}</p>
-                </div>
-                </div>
+        <>
+            <Header />
+            <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 py-12 px-4 sm:px-6 lg:px-8">
+            <div className="max-w-3xl mx-auto">
+                <h1 className="text-3xl font-bold text-center text-indigo-900 mb-8">査定回答</h1>
+                <Card className="bg-white bg-opacity-90">
+                <CardHeader>
+                    <CardTitle className="text-2xl font-bold text-indigo-900">商品情報</CardTitle>
+                </CardHeader>
+                <CardContent className="grid gap-6">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="brandName" className="flex items-center text-lg font-semibold text-gray-700">
+                        <Tag className="w-5 h-5 mr-2 text-blue-500" />
+                        ブランド名
+                        </Label>
+                        <Input
+                        id="brandName"
+                        name="brandName"
+                        value={assessmentData.brandName}
+                        onChange={handleInputChange}
+                        />
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="modelName" className="flex items-center text-lg font-semibold text-gray-700">
+                        <FileText className="w-5 h-5 mr-2 text-purple-500" />
+                        モデル、ライン名
+                        </Label>
+                        <Input
+                        id="modelName"
+                        name="modelName"
+                        value={assessmentData.modelName}
+                        onChange={handleInputChange}
+                        />
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="serialNumber" className="flex items-center text-lg font-semibold text-gray-700">
+                        <FileDigit className="w-5 h-5 mr-2 text-indigo-500" />
+                        型番、シリアル
+                        </Label>
+                        <Input
+                        id="serialNumber"
+                        name="serialNumber"
+                        value={assessmentData.serialNumber}
+                        onChange={handleInputChange}
+                        />
+                    </div>
+                    <div className="space-y-2"></div>
+                    <div className="space-y-2">
+                        <Label htmlFor="responseRangeMin" className="flex items-center text-lg font-semibold text-gray-700">
+                        <Receipt className="w-5 h-5 mr-2 text-pink-500" />
+                        回答額（最小）
+                        </Label>
+                        <Input
+                        id="responseRangeMin"
+                        name="responseRangeMin"
+                        type="number"
+                        value={assessmentData.responseRange.min}
+                        onChange={(e) => handleRangeChange('min', e.target.value)}
+                        />
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="responseRangeMax" className="flex items-center text-lg font-semibold text-gray-700">
+                        <Receipt className="w-5 h-5 mr-2 text-pink-500" />
+                        回答額（最大）
+                        </Label>
+                        <Input
+                        id="responseRangeMax"
+                        name="responseRangeMax"
+                        type="number"
+                        value={assessmentData.responseRange.max}
+                        onChange={(e) => handleRangeChange('max', e.target.value)}
+                        />
+                    </div>
+                    </div>
+                    
+                    {/* Display-only fields */}
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
+                    <div className="space-y-2">
+                        <Label className="text-lg font-semibold text-gray-700">バイヤー予想額</Label>
+                        <p className="text-gray-600">¥{assessmentData.buyerEstimate.toLocaleString()}</p>
+                    </div>
+                    <div className="space-y-2">
+                        <Label className="text-lg font-semibold text-gray-700">状態ランク</Label>
+                        <p className="text-gray-600">{assessmentData.conditionRank}</p>
+                    </div>
+                    <div className="space-y-2 md:col-span-2">
+                        <Label className="text-lg font-semibold text-gray-700">状態補足</Label>
+                        <p className="text-gray-600">{assessmentData.conditionDetails}</p>
+                    </div>
+                    <div className="space-y-2 md:col-span-2">
+                        <Label className="text-lg font-semibold text-gray-700">備考</Label>
+                        <p className="text-gray-600">{assessmentData.notes}</p>
+                    </div>
+                    <div className="space-y-2">
+                        <Label className="text-lg font-semibold text-gray-700">投稿者</Label>
+                        <p className="text-gray-600">{assessmentData.poster}</p>
+                    </div>
+                    </div>
 
-                {/* Image section */}
-                <div className="space-y-2">
-                <Label className="text-lg font-semibold text-gray-700">投稿画像</Label>
-                <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                    <div className="space-y-2">
+                    <Label className="text-lg font-semibold text-gray-700">投稿画像</Label>
+                    <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
                     {assessmentData.images.map((src, index) => (
-                    <ImageDialog key={index} src={src} alt={`商品画像 ${index + 1}`} />
+                    <Dialog key={index}>
+                        <DialogTrigger asChild>
+                        <Image
+                            src={src}
+                            alt={`商品画像 ${index + 1}`}
+                            width={200}
+                            height={200}
+                            className="rounded-md object-cover w-full h-40 cursor-pointer hover:scale-105"
+                        />
+                        </DialogTrigger>
+                        <VisuallyHidden>
+                            <DialogTitle>Hidden Dialog Title</DialogTitle>
+                        </VisuallyHidden>
+                        <DialogContent className="max-w-3xl">
+                                <Image
+                                    src={src}
+                                    alt={`商品画像 ${index + 1}`}
+                                    width={800}
+                                    height={800}
+                                    className="rounded-md object-contain w-full h-full"
+                                />
+                        </DialogContent>
+                    </Dialog>
                     ))}
-                </div>
-                </div>
-            </CardContent>
-            <CardFooter className='grid grid-rows-2 gap-4'>
-                <Button onClick={handleSave} className="w-full">
-                <Save className="w-4 h-4 mr-2" />
-                回答を保存
-                </Button>
-                <Button onClick={handleSave} className="w-full">
-                <Undo2 className="w-4 h-4 mr-2" />
-                保存せずに戻る
-                </Button>
-            </CardFooter>
-            </Card>
-        </div>
-        </div>
+                    </div>
+                    </div>
+                </CardContent>
+                <CardFooter className='grid grid-rows-2 gap-4'>
+                    <Button onClick={handleSave} className="w-full bg-blue-600 hover:bg-blue-700">
+                        <Save className="w-4 h-4 mr-2" />
+                        回答を保存
+                    </Button>
+                    <Link href={`/post-detail/${id}`}>
+                        <Button className="w-full bg-gray-600 hover:bg-gray-700">
+                            <Undo2 className="w-4 h-4 mr-2" />
+                            <span>保存せずに戻る</span>
+                        </Button>
+                    </Link>
+                </CardFooter>
+                </Card>
+            </div>
+            </div>
+        </>
     )
 }

--- a/src/features/components/post-detail/ItemInfo.tsx
+++ b/src/features/components/post-detail/ItemInfo.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import Image from 'next/image'
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -8,6 +10,8 @@ import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
 import image1 from '@/public/images/IMG_0044.jpeg'
 import image2 from '@/public/images/IMG_0045.jpeg'
 import image3 from '@/public/images/IMG_0046.jpeg'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
 
 const ItemInfo = () => {
 
@@ -29,12 +33,17 @@ const ItemInfo = () => {
         respondent: "鈴木花子"
     }
 
+    const params = useParams();
+    const id = params.id
+
     return (
         <Card className="bg-white bg-opacity-90">
         <CardHeader>
             <CardTitle className="flex justify-between text-2xl font-bold text-indigo-900">
                 <strong>商品情報</strong>
-                <Button className='bg-indigo-900 invisible'>編集</Button>
+                <Link href={`/post-response/${id}`}>
+                    <Button className='bg-indigo-900'>回答</Button>
+                </Link>
             </CardTitle>
         </CardHeader>
         <CardContent className="grid gap-4">

--- a/src/features/form/Brand.tsx
+++ b/src/features/form/Brand.tsx
@@ -1,18 +1,18 @@
 import { Tag } from 'lucide-react'
-import { UseFormReturn } from "react-hook-form";
-import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { FormControl, FormField, FormItem, FormLabel } from "@/components/ui/form"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { FormSchemaType } from "../../../lib/schemas/formSchema";
 import { brandNames } from '@/lib/brandNames';
+import { Control, FieldErrors } from 'react-hook-form';
 
-interface ChildComponentProps {
-    form: UseFormReturn<FormSchemaType>;
-}
+type FormPropsType = {
+    control: Control<any>;
+    errors: FieldErrors<any>;
+};
 
-const Brand: React.FC<ChildComponentProps> = ({form}) => {
+const Brand: React.FC<FormPropsType> = ({control, errors}) => {
     return (
         <FormField
-            control={form.control}
+            control={control}
             name="brand"
             render={({ field }) => (
             <FormItem>
@@ -33,7 +33,9 @@ const Brand: React.FC<ChildComponentProps> = ({form}) => {
                         })}
                     </SelectContent>
                 </Select>
-                <FormMessage />
+                {errors?.brand && (
+                    <p className="text-red-500 text-sm mt-1">{errors.brand.message as string}</p>
+                )}
             </FormItem>
             )}
         />

--- a/src/features/form/Condition.tsx
+++ b/src/features/form/Condition.tsx
@@ -1,18 +1,19 @@
-import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { FormControl, FormField, FormItem, FormLabel } from "@/components/ui/form"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { conditionRanks } from "@/lib/conditionRanks";
-import { FormSchemaType } from "@/lib/schemas/formSchema";
 import { Star } from 'lucide-react'
-import { UseFormReturn } from "react-hook-form";
+import { Control, FieldErrors } from "react-hook-form";
 
-interface ChildComponentProps {
-    form: UseFormReturn<FormSchemaType>;
-}
+type FormPropsType = {
+    control: Control<any>;
+    errors: FieldErrors<any>;
+};
 
-const Condition: React.FC<ChildComponentProps> = ({form}) => {
+
+const Condition: React.FC<FormPropsType> = ({control, errors}) => {
     return (
         <FormField
-            control={form.control}
+            control={control}
             name="condition"
             render={({ field }) => (
             <FormItem>
@@ -33,7 +34,9 @@ const Condition: React.FC<ChildComponentProps> = ({form}) => {
                     })}
                 </SelectContent>
                 </Select>
-                <FormMessage />
+                {errors?.condition && (
+                    <p className="text-red-500 text-sm mt-1">{errors.condition.message as string}</p>
+                )}
             </FormItem>
             )}
         />

--- a/src/features/form/ConditionDetails.tsx
+++ b/src/features/form/ConditionDetails.tsx
@@ -1,17 +1,16 @@
 import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
 import { Textarea } from "@/components/ui/textarea"
-import { FormSchemaType } from "@/lib/schemas/formSchema";
 import { FileText } from 'lucide-react'
-import { UseFormReturn } from "react-hook-form";
+import { Control } from "react-hook-form";
 
-interface ChildComponentProps {
-    form: UseFormReturn<FormSchemaType>;
-}
+type FormPropsType = {
+    control: Control<any>;
+};
 
-const ConditionDetails: React.FC<ChildComponentProps> = ({form}) => {
+const ConditionDetails: React.FC<FormPropsType> = ({control}) => {
     return (
         <FormField
-            control={form.control}
+            control={control}
             name="conditionDetails"
             render={({ field }) => (
             <FormItem>

--- a/src/features/form/EstimatedPrice.tsx
+++ b/src/features/form/EstimatedPrice.tsx
@@ -1,18 +1,18 @@
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { FormControl, FormField, FormItem, FormLabel } from "@/components/ui/form"
 import { DollarSign } from 'lucide-react'
-import { FormSchemaType } from "@/lib/schemas/formSchema";
-import { UseFormReturn } from "react-hook-form";
+import { Control, FieldErrors } from "react-hook-form";
 
-interface ChildComponentProps {
-    form: UseFormReturn<FormSchemaType>;
-}
+type FormPropsType = {
+    control: Control<any>;
+    errors: FieldErrors<any>;
+};
 
-const EstimatedPrice: React.FC<ChildComponentProps> = ({form}) => {
+const EstimatedPrice: React.FC<FormPropsType> = ({control, errors}) => {
     return (
         <FormField
-            control={form.control}
+            control={control}
             name="estimatedPrice"
             render={({ field }) => (
             <FormItem>
@@ -55,7 +55,9 @@ const EstimatedPrice: React.FC<ChildComponentProps> = ({form}) => {
                     百万
                 </Button>
                 </div>
-                <FormMessage />
+                {errors?.estimatedPrice && (
+                    <p className="text-red-500 text-sm mt-1">{errors.estimatedPrice.message as string}</p>
+                )}
             </FormItem>
             )}
         />

--- a/src/features/form/Images.tsx
+++ b/src/features/form/Images.tsx
@@ -1,22 +1,23 @@
 import { useState } from "react"
-import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { FormControl, FormDescription, FormField, FormItem, FormLabel } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
 import { Image as ImageIcon } from 'lucide-react'
 import Image from 'next/image'
-import { UseFormReturn } from "react-hook-form"
-import { FormSchemaType } from "@/lib/schemas/formSchema"
+import { Control, FieldErrors, UseFormSetValue } from "react-hook-form"
 
-interface ChildComponentProps {
-    form: UseFormReturn<FormSchemaType>;
-}
+type FormPropsType = {
+    control: Control<any>;
+    setValue: UseFormSetValue<any>;
+    errors: FieldErrors<any>;
+};
 
-const Images: React.FC<ChildComponentProps> = ({form}) => {
+const Images: React.FC<FormPropsType> = ({control, setValue, errors}) => {
 
     const [imagePreview, setImagePreview] = useState<string[]>([])
 
     const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const files = Array.from(e.target.files || [])
-        form.setValue('images', files)
+        setValue('images', files)
         
         const previews = files.map(file => URL.createObjectURL(file))
         setImagePreview(previews)
@@ -24,7 +25,7 @@ const Images: React.FC<ChildComponentProps> = ({form}) => {
 
     return (
         <FormField
-            control={form.control}
+            control={control}
             name="images"
             render={() => (
                 <FormItem>
@@ -68,7 +69,9 @@ const Images: React.FC<ChildComponentProps> = ({form}) => {
                     />
                 </FormControl>
                 <FormDescription>少なくとも1枚の画像をアップロードしてください。複数選択可能です。</FormDescription>
-                <FormMessage />
+                {errors?.images && (
+                    <p className="text-red-500 text-sm mt-1">{errors.images.message as string}</p>
+                )}
                 {imagePreview.length > 0 && (
                     <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
                     {imagePreview.map((src, index) => (

--- a/src/features/form/ModelName.tsx
+++ b/src/features/form/ModelName.tsx
@@ -1,0 +1,33 @@
+import { Input } from "@/components/ui/input"
+import { FormControl, FormField, FormItem, FormLabel } from "@/components/ui/form"
+import { FileText } from 'lucide-react'
+import { Control } from "react-hook-form";
+
+type FormPropsType = {
+    control: Control<any>;
+};
+
+const ModelName: React.FC<FormPropsType> = ({control}) => {
+    return (
+        <FormField
+        control={control}
+        name="notes"
+        render={({ field }) => (
+            <FormItem>
+            <FormLabel className="flex items-center text-lg font-semibold text-gray-700">
+                <FileText className="w-5 h-5 mr-2 text-purple-500" />
+                モデル、ライン名
+            </FormLabel>
+            <FormControl>
+                <Input
+                {...field}
+                className="bg-white border-2 border-gray-300 focus:border-purple-500 focus:ring focus:ring-purple-200 focus:ring-opacity-50 rounded-md shadow-sm"
+                />
+            </FormControl>
+            </FormItem>
+        )}
+        />
+    )
+}
+
+export default ModelName

--- a/src/features/form/Notes.tsx
+++ b/src/features/form/Notes.tsx
@@ -1,17 +1,16 @@
 import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
 import { Textarea } from "@/components/ui/textarea"
-import { FormSchemaType } from "@/lib/schemas/formSchema";
 import { FileText } from 'lucide-react'
-import { UseFormReturn } from "react-hook-form";
+import { Control } from "react-hook-form";
 
-interface ChildComponentProps {
-    form: UseFormReturn<FormSchemaType>;
-}
+type FormPropsType = {
+    control: Control<any>;
+};
 
-const Notes: React.FC<ChildComponentProps> = ({form}) => {
+const Notes: React.FC<FormPropsType> = ({control}) => {
     return (
         <FormField
-        control={form.control}
+        control={control}
         name="notes"
         render={({ field }) => (
             <FormItem>

--- a/src/features/form/ResponseRangeMax.tsx
+++ b/src/features/form/ResponseRangeMax.tsx
@@ -1,0 +1,67 @@
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { FormControl, FormField, FormItem, FormLabel } from "@/components/ui/form"
+import { Receipt } from 'lucide-react'
+import { Control, FieldErrors } from "react-hook-form";
+
+type FormPropsType = {
+    control: Control<any>;
+    errors: FieldErrors<any>;
+};
+
+const ResponseRangeMax: React.FC<FormPropsType> = ({control, errors}) => {
+    return (
+        <FormField
+        control={control}
+        name="responseRangeMax"
+        render={({ field }) => (
+        <FormItem>
+            <FormLabel className="flex items-center text-lg font-semibold text-gray-700">
+                <Receipt className="w-5 h-5 mr-2 text-pink-500" />
+                回答額（最大）
+                <div className='ml-3 text-sm text-red-500'>※必須</div>
+            </FormLabel>
+            <FormControl>
+            <Input
+                type="number"
+                value={field.value ?? ""}
+                onChange={e => {
+                const inputValue = e.target.value;
+                field.onChange(inputValue === "" ? undefined : Number(inputValue));
+                }}
+                className="bg-white border-2 border-gray-300 focus:border-pink-500 focus:ring focus:ring-pink-200 focus:ring-opacity-50 rounded-md shadow-sm"
+            />
+            </FormControl>
+            <div className='flex justify-end gap-2'>
+            <Button
+                type="button"
+                onClick={() => field.onChange(Math.floor((field.value || 0) * 10000))}
+                className="px-3 py-1 bg-pink-500 hover:bg-pink-600 text-white rounded-md"
+            >
+                万
+            </Button>
+            <Button
+                type="button"
+                onClick={() => field.onChange(Math.floor((field.value || 0) * 100000))}
+                className="px-3 py-1 bg-pink-500 hover:bg-pink-600 text-white rounded-md"
+            >
+                十万
+            </Button>
+            <Button
+                type="button"
+                onClick={() => field.onChange(Math.floor((field.value || 0) * 1000000))}
+                className="px-3 py-1 bg-pink-500 hover:bg-pink-600 text-white rounded-md"
+            >
+                百万
+            </Button>
+            </div>
+            {errors?.responseRangeMax && (
+                <p className="text-red-500 text-sm mt-1">{errors.responseRangeMax.message as string}</p>
+            )}
+        </FormItem>
+        )}
+    />
+    )
+}
+
+export default ResponseRangeMax

--- a/src/features/form/ResponseRangeMin.tsx
+++ b/src/features/form/ResponseRangeMin.tsx
@@ -1,0 +1,67 @@
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { FormControl, FormField, FormItem, FormLabel } from "@/components/ui/form"
+import { Receipt } from 'lucide-react'
+import { Control, FieldErrors } from "react-hook-form";
+
+type FormPropsType = {
+    control: Control<any>;
+    errors: FieldErrors<any>;
+};
+
+const ResponseRangeMin: React.FC<FormPropsType> = ({control, errors}) => {
+    return (
+        <FormField
+        control={control}
+        name="responseRangeMin"
+        render={({ field }) => (
+        <FormItem>
+            <FormLabel className="flex items-center text-lg font-semibold text-gray-700">
+                <Receipt className="w-5 h-5 mr-2 text-pink-500" />
+                回答額（最小）
+                <div className='ml-3 text-sm text-red-500'>※必須</div>
+            </FormLabel>
+            <FormControl>
+            <Input
+                type="number"
+                value={field.value ?? ""}
+                onChange={e => {
+                const inputValue = e.target.value;
+                field.onChange(inputValue === "" ? undefined : Number(inputValue));
+                }}
+                className="bg-white border-2 border-gray-300 focus:border-pink-500 focus:ring focus:ring-pink-200 focus:ring-opacity-50 rounded-md shadow-sm"
+            />
+            </FormControl>
+            <div className='flex justify-end gap-2'>
+            <Button
+                type="button"
+                onClick={() => field.onChange(Math.floor((field.value || 0) * 10000))}
+                className="px-3 py-1 bg-pink-500 hover:bg-pink-600 text-white rounded-md"
+            >
+                万
+            </Button>
+            <Button
+                type="button"
+                onClick={() => field.onChange(Math.floor((field.value || 0) * 100000))}
+                className="px-3 py-1 bg-pink-500 hover:bg-pink-600 text-white rounded-md"
+            >
+                十万
+            </Button>
+            <Button
+                type="button"
+                onClick={() => field.onChange(Math.floor((field.value || 0) * 1000000))}
+                className="px-3 py-1 bg-pink-500 hover:bg-pink-600 text-white rounded-md"
+            >
+                百万
+            </Button>
+            </div>
+            {errors?.responseRangeMin && (
+                <p className="text-red-500 text-sm mt-1">{errors.responseRangeMin.message as string}</p>
+            )}
+        </FormItem>
+        )}
+    />
+    )
+}
+
+export default ResponseRangeMin

--- a/src/features/form/SerialNumber.tsx
+++ b/src/features/form/SerialNumber.tsx
@@ -1,0 +1,33 @@
+import { Input } from "@/components/ui/input"
+import { FormControl, FormField, FormItem, FormLabel } from "@/components/ui/form"
+import { FileDigit } from 'lucide-react'
+import { Control } from "react-hook-form";
+
+type FormPropsType = {
+    control: Control<any>;
+};
+
+const SerialNumber: React.FC<FormPropsType> = ({control}) => {
+    return (
+        <FormField
+        control={control}
+        name="notes"
+        render={({ field }) => (
+            <FormItem>
+            <FormLabel className="flex items-center text-lg font-semibold text-gray-700">
+                <FileDigit className="w-5 h-5 mr-2 text-indigo-500" />
+                型番、シリアル
+            </FormLabel>
+            <FormControl>
+                <Input
+                {...field}
+                className="bg-white border-2 border-gray-300 focus:border-indigo-500 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 rounded-md shadow-sm"
+                />
+            </FormControl>
+            </FormItem>
+        )}
+        />
+    )
+}
+
+export default SerialNumber

--- a/src/lib/schemas/formSchema.ts
+++ b/src/lib/schemas/formSchema.ts
@@ -10,3 +10,28 @@ export const formSchema = z.object({
 })
 
 export type FormSchemaType = z.infer<typeof formSchema>;
+
+export const responseSchema = z.object({
+    brand: z.string().min(1, { message: "ブランド名を選択してください" }),
+    responseMin: z.number().positive({ message: "回答額を入力してください" }),
+    responseMax: z.number().positive({ message: "回答額を入力してください" }),
+    modelName: z.string().optional(),
+    serialNumber: z.string().optional(),
+})
+
+export type responseSchemaType = z.infer<typeof responseSchema>;
+
+export const appraisalPostsSchema = z.object({
+    brand: z.string().min(1, { message: "ブランド名を選択してください" }),
+    estimatedPrice: z.number().positive({ message: "予想金額を入力してください" }),
+    responseMin: z.number().positive({ message: "回答額を入力してください" }),
+    responseMax: z.number().positive({ message: "回答額を入力してください" }),
+    condition: z.string().min(1, { message: "状態ランクを選択してください" }),
+    conditionDetails: z.string().optional(),
+    modelName: z.string().optional(),
+    serialNumber: z.string().optional(),
+    notes: z.string().optional(),
+    images: z.array(z.instanceof(File)).refine((files) => files.length > 0, "少なくとも1枚の画像をアップロードしてください")
+})
+
+export type appraisalPostsSchemaType = z.infer<typeof appraisalPostsSchema>;


### PR DESCRIPTION
# 概要
- フォームの各、子コンポーネントを複数のページで使えるよう調整
- post-detailページに査定回答ページに遷移するボタンを作成