### PR TITLE
エラーメッセージの表記方法を統一化

### DIFF
--- a/src/app/all-posts/page.tsx
+++ b/src/app/all-posts/page.tsx
@@ -29,7 +29,7 @@ export default function AllPosts() {
             const {data , error} = await getAppraisalPosts(searchPoster, targetDate)
 
             if(error){
-                window.alert("エラー")
+                window.alert("エラー: " + error.message)
             }else{
                 setPosts(data)
             }

--- a/src/app/buyer/Home/page.tsx
+++ b/src/app/buyer/Home/page.tsx
@@ -28,7 +28,7 @@ const Page = () => {
                 try {
                     const { data, error } = await getTodayAppraisalPostsByUser(user.uid);
                     if (error) {
-                        throw new Error(error.message);
+                        window.alert("エラー: " + error.message);
                     }
                     setPosts(data);
                 } catch (err: any) {

--- a/src/app/buyer/newPost/page.tsx
+++ b/src/app/buyer/newPost/page.tsx
@@ -55,16 +55,15 @@ export default function AssessmentForm() {
             const { error } = await addAppraisalPost(values, user.uid, user.displayName);
             
             if (error) {
-                throw new Error(`エラーが発生しました: ${error}`);
+                window.alert("エラー: " + error);
             }
             
             await router.push("/buyer/Home");
         } else {
-            throw new Error("ユーザー情報が不足しています");
+            window.alert("ユーザー情報が不足しています");
         }
     } catch (err) {
-        console.error(err);
-        window.alert(err || "エラーが発生しました");
+        window.alert("エラー: " + err);
     } finally {
         setIsLoading(false);
     }

--- a/src/app/select-usertype/page.tsx
+++ b/src/app/select-usertype/page.tsx
@@ -26,7 +26,7 @@ const Page = () => {
         if(user && user.displayName && user.email){
             const { error } = await addUser(user.uid, user.displayName, user.email, type)
             if(error){
-                window.alert("【エラー】")
+                window.alert("エラー:" + error.message)
                 setIsLoading(false)
                 return
             }

--- a/src/features/components/post-response/ResponseForm.tsx
+++ b/src/features/components/post-response/ResponseForm.tsx
@@ -88,13 +88,13 @@ const ResponseForm = () => {
                 if( !error ) {
                     router.push(`/post-detail/${id}`)
                 }else{
-                    window.alert("エラーが発生しました")
+                    window.alert("エラー: " + error)
                 }
             }else{
                 window.alert("エラーが発生しました")
             }
-        }catch{
-            window.alert("エラーが発生しました")
+        }catch(error: any){
+            window.alert("エラー: " + error)
         }
     }
 


### PR DESCRIPTION
# 概要
エラーメッセージの表記方法にばらつきがあったため
全てのコンポーネントで統一