### PR TITLE
4点修正

### DIFF
--- a/src/app/all-posts/page.tsx
+++ b/src/app/all-posts/page.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { useState } from 'react'
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
-import { Calendar as CalendarIcon, Search } from 'lucide-react'
+import { Calendar as CalendarIcon, ChevronLeft, ChevronRight, Search } from 'lucide-react'
 import { format } from "date-fns"
 import { Calendar } from "@/components/ui/calendar"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
@@ -20,6 +20,9 @@ export default function AllPosts() {
     const [searchPoster, setSearchPoster] = useState("")
     const [ posts , setPosts ] = useState<appraisal_posts[] | null>(null)
     const [ isLoading, setIsloading ] = useState<boolean>(false);
+    const [ currentPage, setCurrentPage ] = useState<number>(1);
+
+    const itemsPerPage = 10;
 
     const handleSearch = async() => {
         if( searchDate && searchPoster ){
@@ -32,6 +35,7 @@ export default function AllPosts() {
                 window.alert("エラー: " + error.message)
             }else{
                 setPosts(data)
+                setCurrentPage(1)
             }
 
             setIsloading(false)
@@ -39,6 +43,8 @@ export default function AllPosts() {
             window.alert("検索値を設定してください")
         }
     }
+
+    const totalPages = posts ? Math.ceil(posts.length / itemsPerPage) : 0;
 
     return (
         <>
@@ -100,8 +106,38 @@ export default function AllPosts() {
                             <CardTitle className="text-2xl font-bold text-indigo-900">投稿一覧</CardTitle>
                         </CardHeader>
                         <CardContent>
-                            <ItemsList posts={posts} loading={isLoading} />
+                            <ItemsList posts={posts} loading={isLoading} currentPage={currentPage} itemsPerPage={itemsPerPage} />
                         </CardContent>
+                        <CardFooter className="flex justify-center gap-2">
+                        {
+                            totalPages ?
+                            <>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => setCurrentPage(prev => Math.max(prev - 1, 1))}
+                                    disabled={currentPage === 1}
+                                >
+                                    <ChevronLeft className="h-4 w-4" />
+                                    <strong className='hidden sm:inline'>前へ</strong>
+                                </Button>
+                                <span className="text-sm">
+                                    {currentPage} / {totalPages}
+                                </span>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => setCurrentPage(prev => Math.min(prev + 1, totalPages))}
+                                    disabled={currentPage === totalPages}
+                                >
+                                    <strong className='hidden sm:inline'>次へ</strong>
+                                    <ChevronRight className="h-4 w-4" />
+                                </Button>
+                            </>
+                            :
+                            <></>
+                        }
+                        </CardFooter>
                     </Card>
                 </div>
             </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="jp" className="mdl-js">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100`}
       >

--- a/src/features/PostsList.tsx
+++ b/src/features/PostsList.tsx
@@ -28,8 +28,8 @@ const PostsList = ({ posts, loading, currentPage = 0, itemsPerPage = 0 }: propsT
             <Table>
                 <TableHeader>
                     <TableRow>
-                        <TableHead className="w-[120px]">サムネイル</TableHead>
-                        <TableHead className="w-[80px]">ID</TableHead>
+                        <TableHead className="w-[80px] lg:w-[120px]">サムネイル</TableHead>
+                        <TableHead className="w-[50px]">ID</TableHead>
                         <TableHead className='hidden sm:table-cell'>ブランド名</TableHead>
                         <TableHead className='hidden sm:table-cell'>モデル名</TableHead>
                         <TableHead className='hidden sm:table-cell'>投稿日時</TableHead>

--- a/src/features/PostsList.tsx
+++ b/src/features/PostsList.tsx
@@ -5,9 +5,19 @@ import { appraisal_posts } from '@/types/supabaseTableTypes'
 type propsType = {
     posts : appraisal_posts[] | null
     loading: boolean
+    currentPage?: number
+    itemsPerPage?: number
 }
 
-const PostsList = ({ posts, loading }: propsType) => {
+const PostsList = ({ posts, loading, currentPage = 0, itemsPerPage = 0 }: propsType) => {
+
+    if(currentPage && itemsPerPage && posts){
+        posts = posts.slice(
+            (currentPage - 1) * itemsPerPage,
+            currentPage * itemsPerPage
+        )
+    }
+
     return (
         <div className="relative overflow-x-auto -mx-6 px-6">
             {loading && (

--- a/src/lib/schemas/formSchema.ts
+++ b/src/lib/schemas/formSchema.ts
@@ -2,7 +2,7 @@ import * as z from 'zod'
 
 export const formSchema = z.object({
     brand: z.string().min(1, { message: "ブランド名を選択してください" }),
-    estimatedPrice: z.number().positive({ message: "予想金額を入力してください" }),
+    estimatedPrice: z.number({ message: "予想金額を入力してください" }).min(0, { message: "正しい予想金額を入力してください" }),
     conditionRank: z.string().min(1, { message: "状態ランクを選択してください" }),
     conditionDetails: z.string().optional(),
     notes: z.string().optional(),
@@ -13,8 +13,8 @@ export type FormSchemaType = z.infer<typeof formSchema>;
 
 export const responseSchema = z.object({
     brand: z.string().min(1, { message: "ブランド名を選択してください" }),
-    responseMin: z.number().min(0, { message: "正しい回答額を入力してください" }),
-    responseMax: z.number().min(0, { message: "正しい回答額を入力してください" }),
+    responseMin: z.number({ message: "予想金額を入力してください" }).min(0, { message: "正しい回答額を入力してください" }),
+    responseMax: z.number({ message: "予想金額を入力してください" }).min(0, { message: "正しい回答額を入力してください" }),
     modelName: z.string().optional(),
     serialNumber: z.string().optional(),
 })


### PR DESCRIPTION
# 概要
- all-postsページのリストが多数表示されることを考慮して、10件ずつページで区切る
- iPhoneSEなどの小さいモバイル画面でもリストが綺麗に表示されるようスタイルの修正
- lang="jp"に変更、Hydration failedのエラー修正
- 予想額、回答額が空白の場合のエラーメッセージが正しく表示されていなかったため修正